### PR TITLE
Made panel resizable

### DIFF
--- a/styles/ember-cli-helper.less
+++ b/styles/ember-cli-helper.less
@@ -34,6 +34,18 @@
     }
   }
 
+
+  // Panel resize handle
+  .ember-cli-resize-handle {
+    position: absolute;
+    right: 0;
+    left: 0;
+    top: -5px;
+    height: 10px;
+    cursor: ns-resize;
+    z-index: 3;
+  }
+
 }
 
 .ember-cli-btn-group:extend(.btn-group) {


### PR DESCRIPTION
Added resize functionality to the panel, using inspiration (and a code snippet) from Atom's `tree-view` package. The implementation is fairly straightforward, hopefully.

[also, ignore the goofy branch name. I typed 'scroll' instead of 'resize' and found out about it after pushing to github. derp!]
