### PR TITLE
Restyled panel (Monospace font + background color)

### DIFF
--- a/lib/ember-cli-helper-view.coffee
+++ b/lib/ember-cli-helper-view.coffee
@@ -8,7 +8,7 @@ module.exports =
 class EmberCliHelperView extends View
 
   @content: ->
-    @div class: 'ember-cli-helper tool-panel panel-bottom native-key-bindings', =>
+    @div class: 'ember-cli-helper native-key-bindings', =>
       @div class: 'ember-cli-resize-handle', outlet: 'resizeHandle'
       @div class: 'ember-cli-btn-group', outlet: 'buttonGroup', =>
         @div class: 'block', =>

--- a/styles/ember-cli-helper.less
+++ b/styles/ember-cli-helper.less
@@ -7,7 +7,15 @@
 .ember-cli-helper {
   .panel-body {
     height: 95px;
-    overflow: scroll;
+    overflow-y: scroll;
+    border-top: 1px solid @inset-panel-border-color;
+    background-color: @inset-panel-background-color;
+    font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+
+    li {
+      white-space: pre;
+      line-height: 1.5;
+    }
   }
   .btn:focus {
     outline: 0;


### PR DESCRIPTION
Last change in my recent 'series': did a bit of restyling on the server info panel for a slightly cleaner (IMO) look and feel.

Styling is generally a subjective thing, though in this case I felt it was important for the server output since `ember-cli` relies on monospacing to align its output. I made sure to use standard Atom styles, so it works across different themes:

![Preview 1](http://i.imgur.com/NL0xG2H.png)
![Preview 2](http://i.imgur.com/gkeEkzS.png)
![Preview 3](http://i.imgur.com/rB8zHTv.png)

Feedback is welcome, especially since it's more subjective than my other PRs.
